### PR TITLE
Add Invalid_argument active pattern to fix failing chop_extension test

### DIFF
--- a/FSharp.Compatibility.OCaml/Core.fs
+++ b/FSharp.Compatibility.OCaml/Core.fs
@@ -63,6 +63,16 @@ exception Undefined
 [<Obsolete("Code which raises Invalid_argument should be changed to raise System.ArgumentException instead.")>]
 exception Invalid_argument of string
 
+[<CompiledName("InvalidArgumentPattern")>]
+let (|Invalid_argument|_|) (ex : exn) =
+    // This allows us to match both the Invalid_argument type and System.ArgumentException
+    match ex with
+    | :? Invalid_argument as ia ->
+        Some ia.Data0
+    | :? System.ArgumentException as ae ->
+        Some ae.Message
+    | _ -> None
+
 /// Exception raised by library functions to signal that they are undefined on the given arguments.
 // TODO : Should this just be an alias for System.Exception (exn) so it can be matched
 // by the built-in F# Failure pattern?


### PR DESCRIPTION
- The test is failing because it matches on an Invalid_argument exception, but the function actually throws System.ArgumentException
- An Invalid_argument pattern was in the original powerpack version of this file: https://github.com/fsprojects/powerpack/blob/93fd7200f7f46b2be281a1295a96e4a8f3ef6c7b/src/FSharp.PowerPack.Compatibility/pervasives.fs
That pattern was removed sometime before this file was committed here, but given that the "Failure" pattern was added here which does something similar, it seems to be a valid way to fix this issue