### PR TITLE
Haskell Compatibility ported from F#+

### DIFF
--- a/FSharp.Compatibility.Haskell/FSharp.Compatibility.Haskell.fsproj
+++ b/FSharp.Compatibility.Haskell/FSharp.Compatibility.Haskell.fsproj
@@ -33,9 +33,6 @@
     <DocumentationFile>bin\Release\FSharp.Compatibility.Haskell.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,7 +44,8 @@
     </Compile>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Prelude.fs" />
-    <None Include="paket.references" />    
+    <None Include="paket.references" />
+    <None Include="Sample.fsx" />
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
@@ -66,4 +64,80 @@
   </Choose>
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <Import Project="$(SolutionDir)\.paket\paket.targets" />
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v2.2' Or $(TargetFrameworkVersion) == 'v2.3' Or $(TargetFrameworkVersion) == 'v4.0.3' Or $(TargetFrameworkVersion) == 'v4.1' Or $(TargetFrameworkVersion) == 'v4.2' Or $(TargetFrameworkVersion) == 'v4.3' Or $(TargetFrameworkVersion) == 'v4.4' Or $(TargetFrameworkVersion) == 'v5.0' Or $(TargetFrameworkVersion) == 'v5.1' Or $(TargetFrameworkVersion) == 'v6.0' Or $(TargetFrameworkVersion) == 'v7.0' Or $(TargetFrameworkVersion) == 'v7.1' Or $(TargetFrameworkVersion) == 'v8.0')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\MonoAndroid\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoTouch'">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\MonoTouch\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.0.3' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And ($(TargetFrameworkVersion) == 'v1.0' Or $(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6' Or $(TargetFrameworkVersion) == 'v2.0')) Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkIdentifier) == 'Xamarin.tvOS') Or ($(TargetFrameworkIdentifier) == 'Xamarin.watchOS')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkProfile) == 'Profile78') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1'))">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkProfile) == 'Profile259') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkIdentifier) == '.NETCore' And $(TargetFrameworkVersion) == 'v5.0')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile47') Or ($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+sl5+netcore45+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.0.3' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3' Or $(TargetFrameworkVersion) == 'v4.7' Or $(TargetFrameworkVersion) == 'v4.7.1')">
+      <ItemGroup>
+        <Reference Include="FSharpPlus">
+          <HintPath>..\packages\FSharpPlus\lib\net40\FSharpPlus.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/FSharp.Compatibility.Haskell/Prelude.fs
+++ b/FSharp.Compatibility.Haskell/Prelude.fs
@@ -146,18 +146,18 @@ let replicate  n x = List.replicate  n x
 
 open System.Reflection
 let cycle lst =
-    let mutable last = lst
+    let last = ref lst
     let rec copy = function
         | [] -> failwith "empty list"
         | [z] -> 
             let v = [z]
-            last <- v
+            last.Value <- v
             v
         | x::xs ->  x::copy xs
     let cycled = copy lst
-    let strs = last.GetType().GetFields(BindingFlags.NonPublic ||| BindingFlags.Instance) |> Array.map (fun field -> field.Name)
-    let tailField = last.GetType().GetField(Array.find(fun (s:string) -> s.ToLower().Contains("tail")) strs, BindingFlags.NonPublic ||| BindingFlags.Instance)
-    tailField.SetValue(last, cycled)
+    let strs = last.Value.GetType().GetFields(BindingFlags.NonPublic ||| BindingFlags.Instance) |> Array.map (fun field -> field.Name)
+    let tailField = last.Value.GetType().GetField(Array.find(fun (s:string) -> s.ToLower().Contains("tail")) strs, BindingFlags.NonPublic ||| BindingFlags.Instance)
+    tailField.SetValue(last.Value, cycled)
     cycled
 
 let drop i list = 

--- a/FSharp.Compatibility.Haskell/Prelude.fs
+++ b/FSharp.Compatibility.Haskell/Prelude.fs
@@ -1,55 +1,344 @@
-﻿(*
-
-Copyright 2013 Jack Pappas
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
+﻿(**
+Haskell Compatibility
+=====================
+ - This module helps to run Haskell fragments or to port code from/to Haskell.
+ - By opening this module many F# and F#+ operators get shadowed.
+Here's a table listing some common operators/functions:
+```
++-----------------------+-----------------------+--------------------+
+| Operation             | Haskell-Compatibility | Haskell            |
++=======================+=======================+====================+
+| List.append           | ++                    | ++                 |
++-----------------------+-----------------------+--------------------+
+| Function composition  | f . (g)               | f . g              |
++-----------------------+-----------------------+--------------------+
+| Equality              | ==                    | ==                 |
++-----------------------+-----------------------+--------------------+
+| Avoid Parentheses     | $                     | $                  |
++-----------------------+-----------------------+--------------------+
+| Inequality            | =/                    | /=                 |
++-----------------------+-----------------------+--------------------+
+| Flip                  | flip                  | flip               |
++-----------------------+-----------------------+--------------------+
+| Apply function        | not available         | not available      | 
+| to a value            | in Haskell            | in Haskell         |
++-----------------------+-----------------------+--------------------+
+|                       |                       |                    |
++-----------------------+-----------------------+--------------------+
+| Functors                                                           |
++-----------------------+-----------------------+--------------------+
+| Map                   | <!> or fmap           | <$> or fmap        |
++-----------------------+-----------------------+--------------------+
+| Map with              |                       |                    |
+| interchanged          |                       |                    |
+| arguments             |                       |                    |
++-----------------------+-----------------------+--------------------+
+|                       |                       |                    |
++-----------------------+-----------------------+--------------------+
+| Monoids                                                            |
++-----------------------+-----------------------+--------------------+
+| Zero element          | mempty                | mempty             |
++-----------------------+-----------------------+--------------------+
+| Append                | mappend               | mappend            |
++-----------------------+-----------------------+--------------------+
+|                       |                       |                    |
++-----------------------+-----------------------+--------------------+
+| Applicative functors                                               |
++-----------------------+-----------------------+--------------------+
+| Apply (combine)       | <*>                   | <*>                |
++-----------------------+-----------------------+--------------------+
+| Sequence actions      |                       |                    |
+| and discard values    | *>                    | *>                 |
+| of first argument     |                       |                    |
++-----------------------+-----------------------+--------------------+
+| Sequence actions      |                       |                    |
+| and discard values    | <*                    | <*                 |
+| of second argument    |                       |                    |
++-----------------------+-----------------------+--------------------+
+| A variant of <*>      |                       |                    |
+| with the arguments    | <**>                  | <**>               |
+| reversed.             |                       |                    |
++-----------------------+-----------------------+--------------------+
+| Lift a value.         | pure'                 | pure               |
++-----------------------+-----------------------+--------------------+
+|                       |                       |                    |
++-----------------------+-----------------------+--------------------+
+| Alternatives                                                       |
++-----------------------+-----------------------+--------------------+
+| Binary operation      | <|>                   | <|>                |
++-----------------------+-----------------------+--------------------+
+|                       |                       |                    |
++-----------------------+-----------------------+--------------------+
+| Monads                                                             |
++-----------------------+-----------------------+--------------------+
+| Bind sequentially and |                       |                    |
+| compose two actions,  |                       |                    |
+| passing any value     | >>=                   | >>=                |
+| produced by the       |                       |                    |
+| first as an argument  |                       |                    |
+| to the second.        |                       |                    |
++-----------------------+-----------------------+--------------------+
+| Bind with             |                       |                    |
+| interchanged          | =<<                   | =<<                |
+| arguments.            |                       |                    |
++-----------------------+-----------------------+--------------------+
+```
 *)
-
 module FSharp.Compatibility.Haskell.Prelude
 
-(* Type extensions for built-in .NET and F# types *)
+open FSharpPlus
+open FSharpPlus.Data
 
-//
-let inline (++) (str1 : string) (str2 : string) =
-    System.String.Concat (str1, str2)
+let getDual (Dual x) = x
+let getAll (All x) = x
+let getAny (Any x) = x
+let getFirst (First x) = x
+let getLast (Last x) = x
+let runKleisli (Kleisli f) = f
 
-//
-let inline show x =
-    x.ToString ()
+// Operatots
+let ($)   x y = x y
+let (.()) x y = x << y
+let const' k _ = k
+let (==) = (=)
+let (=/) x y = not (x = y)
 
-// Haskell              | F#
-//---------------------------------
-// rem                  | %
-// mod                  | ?
-// quot                 | /
-// div                  | ?
-// divMod               | ?
-// quotRem              | divRem
+type DeReference_op = DeReference_op with
+    static member (=>) (DeReference_op, a:'a ref        ) = !a
+    static member (=>) (DeReference_op, a:string        ) = a.ToCharArray() |> Array.toList
+    static member (=>) (DeReference_op, _:DeReference_op) = DeReference_op
+
+/// converts a string to list<char> otherwise still works as dereference operator.
+let inline (!) a = DeReference_op => a
+
+let show x = '\"' :: x ++ !"\""
+
+type Maybe<'t> = Option<'t>
+let  Just x :Maybe<'t> = Some x
+let  Nothing:Maybe<'t> = None
+let  (|Just|Nothing|) = function Some x -> Just x | _ -> Nothing
+let maybe  n f = function | Nothing -> n | Just x -> f x
 
 /// Type abbreviation for Haskell's Either type.
 // NOTE : If the Haskell Either type were directly translated to use Choice`2, then Left would become
 // Choice1Of2 and Right would become Choice2Of2. However, this pattern "inverts" the translation,
 // because Choice1Of2 and Right normally represent a "success" value while Choice2Of2 and Left
 // represent an "error" value.
-type Either<'a, 'b> = Choice<'b, 'a>
+type Either<'a,'b> = Choice<'b,'a>
+let  Right x :Either<'a,'b> = Choice1Of2 x
+let  Left  x :Either<'a,'b> = Choice2Of2 x
+let  (|Right|Left|) = function Choice1Of2 x -> Right x | Choice2Of2 x -> Left x
+let either f g = function Left x -> f x | Right y -> g y
 
-/// Active pattern which simulates Either using the Choice type.
-let inline (|Right|Left|) (either : Either<'a, 'b>) : Either<_,_> =
-    match either with
-    | Choice1Of2 x ->
-        Right x
-    | Choice2Of2 x ->
-        Left x
+// IO
+type IO<'a> = Async<'a>
+let runIO (f:IO<'a>) = Async.RunSynchronously f
+let getLine    = async {return System.Console.ReadLine()} :IO<string>
+let putStrLn x = async {printfn "%s" x}                   :IO<unit>
+let print    x = async {printfn "%A" x}                   :IO<unit>
 
 
+// List
+
+let map f x = List.map f x
+
+let replicate  n x = List.replicate  n x
+
+open System.Reflection
+let cycle lst =
+    let mutable last = lst
+    let rec copy = function
+        | [] -> failwith "empty list"
+        | [z] -> 
+            let v = [z]
+            last <- v
+            v
+        | x::xs ->  x::copy xs
+    let cycled = copy lst
+    let strs = last.GetType().GetFields(BindingFlags.NonPublic ||| BindingFlags.Instance) |> Array.map (fun field -> field.Name)
+    let tailField = last.GetType().GetField(Array.find(fun (s:string) -> s.ToLower().Contains("tail")) strs, BindingFlags.NonPublic ||| BindingFlags.Instance)
+    tailField.SetValue(last, cycled)
+    cycled
+
+let drop i list = 
+    let rec loop i lst = 
+        match (lst, i) with
+        | ([] as x, _) | (x, 0) -> x
+        | x, n -> loop (n-1) (List.tail x)
+    if i > 0 then loop i list else list
+
+let take i (list:_ list) = Seq.truncate i list |> Seq.toList
+
+
+// Functors
+
+let inline fmap f x = map f x
+
+// Applicative functors
+            
+let inline pure' x   = result x
+let inline empty()   = getMZero()    
+let inline optional v = Just <!> v <|> pure' Nothing
+
+// Monoids
+
+let inline mempty() = getEmpty()
+let inline mappend a b = append a b
+let inline mconcat s = concat s
+
+type Ordering = LT|EQ|GT with
+    static member        Empty = EQ
+    static member        Append (x:Ordering, y) = 
+        match x, y with
+        | LT, _ -> LT
+        | EQ, a -> a
+        | GT, _ -> GT
+
+let inline compare x y =
+    match compare x y with
+    | a when a > 0 -> GT
+    | a when a < 0 -> LT
+    | _            -> EQ
+
+
+// Foldable
+let inline foldr (f: 'a -> 'b -> 'b) (z:'b) x :'b = foldBack f x z
+let inline foldl (f: 'b -> 'a -> 'b) (z:'b) x :'b = fold     f z x
+
+
+// Numerics
+open GenericMath
+
+type Integer = bigint
+
+let inline fromInteger  (x:Integer)   :'Num    = fromBigInt x
+let inline toInteger    (x:'Integral) :Integer = toBigInt   x
+let inline fromIntegral (x:'Integral) :'Num = (fromInteger << toInteger) x
+
+let inline _whenIntegral a = let _ = if false then toBigInt a else 0I in ()
+
+let inline div (a:'Integral) b :'Integral =
+    _whenIntegral a
+    let (a,b) = if b < 0G then (-a,-b) else (a,b)
+    (if a < 0G then (a - b + 1G) else a) / b
+            
+let inline quot (a:'Integral) (b:'Integral) :'Integral = _whenIntegral a; a / b
+let inline rem  (a:'Integral) (b:'Integral) :'Integral = _whenIntegral a; a % b
+let inline quotRem a b :'Integral * 'Integral = _whenIntegral a; divRem a b
+let inline mod'   a b :'Integral = _whenIntegral a; ((a % b) + b) % b
+let inline divMod D d :'Integral * 'Integral =
+    let q, r = quotRem D d
+    if (r < 0G) then
+        if (d > 0G) then (q - 1G, r + d)
+        else             (q + 1G, r - d)
+    else (q, r)
+
+
+let inline ( **) a (b:'Floating) :'Floating = a ** b
+let inline sqrt    (x:'Floating) :'Floating = Microsoft.FSharp.Core.Operators.sqrt x
+            
+let inline asinh x :'Floating = log (x + sqrt (1G+x*x))
+let inline acosh x :'Floating = log (x + (x+1G) * sqrt ((x-1G)/(x+1G)))
+let inline atanh x :'Floating = (1G/2G) * log ((1G+x) / (1G-x))
+            
+let inline logBase x y  :'Floating =  log y / log x
+
+
+/// Monad
+
+let inline return' x = result x
+
+let inline sequence ms = List.sequence ms
+let inline replicateM n x = List.replicateM n x            
+let inline mapM f as' = List.traverse f as'
+let inline filterM p x = List.filterM p x
+let inline liftM  f m1    = m1 >>= (return' << f)
+let inline liftM2 f m1 m2 = m1 >>= fun x1 -> m2 >>= fun x2 -> return' (f x1 x2)
+let inline ap     x y     = liftM2 id x y
+            
+let do' = new Builders.MonadBuilder()
+
+
+// Monad Plus
+let inline mzero() = getMZero()
+let inline mplus (x:'a) (y:'a) : 'a = (<|>) x y
+let inline guard x = if x then return' () else mzero()
+
+
+
+
+// Arrow
+let inline id'() = getCatId ()
+let inline (<<<) f g = catComp f g
+let inline (>>>) f g = catComp g f
+let inline (&&&) f g = fanout f g
+let inline (|||) f g = fanin  f g
+let inline app() = getApp ()
+let inline zeroArrow() = mzero ()
+let inline (<+>)   f g = (<|>) f g
+
+
+// Cont
+
+let callCC' = Cont.callCC
+let inline when'  p s = if p then s else return' ()
+let inline unless p s = when' (not p) s
+
+let runCont = Cont.run
+type Cont = Cont
+let Cont = Cont.Cont
+            
+
+// Reader
+
+let ask'      = Reader.ask
+let local'    = Reader.local
+
+let runReader = Reader.run
+type Reader = Reader
+let Reader = Reader.Reader
+            
+
+// State
+
+let get'      = State.get
+let put'      = State.put
+let execState = State.exec
+
+let runState  = State.run
+type State = State
+let State = State.State
+
+            
+// Monad Transformers
+type MaybeT<'T> = OptionT<'T>
+let MaybeT  x = OptionT x
+let runMaybeT = OptionT.run
+let inline mapMaybeT f x = OptionT.map f x
+let runListT  = ListT.run
+let inline liftIO (x: IO<'a>) = liftAsync x
+
+        
+// ContT
+let runContT  = ContT.run
+type ContT = ContT
+let ContT = ContT.ContT
+            
+// ReaderT
+let runReaderT = ReaderT.run
+type ReaderT = ReaderT
+let ReaderT = ReaderT.ReaderT
+            
+// StateT
+let runStateT = StateT.run
+type StateT = StateT
+let StateT = StateT.StateT
+            
+// MonadError
+let inline throwError x   = throw x
+let inline catchError v h = catch v h
+            
+// ErrorT
+let runErrorT = ErrorT.run
+type ErrorT = ErrorT
+let ErrorT = ErrorT.ErrorT

--- a/FSharp.Compatibility.Haskell/Sample.fsx
+++ b/FSharp.Compatibility.Haskell/Sample.fsx
@@ -1,0 +1,106 @@
+﻿#r @"bin\Release\FSharpPlus.dll"
+#r @"bin\Release\FSharp.Compatibility.Haskell.dll"
+
+(*
+Examples
+========
+You may run this script step-by-step.
+*)
+
+open FSharpPlus
+open FSharp.Compatibility.Haskell.Prelude
+open FSharpPlus.Data
+
+#nowarn "62"
+
+
+
+
+
+// Operators
+
+let res9 = ((+) 5) $ 4
+let res10 = filter ((=/) 9) ([9] ++ [10])
+let halfThenSqrt = sqrt . (flip (/) 2.0) 
+
+
+// IO
+
+let main = print (halfThenSqrt 32.0)
+runIO main                                                  // prints 4.0
+let get3strings  = sequenceA [getLine;getLine;getLine]      // try runIO get3strings
+
+
+// Test IO
+let action = do' {
+    do! putStrLn  "What is your first name?"
+    let! fn = getLine
+    do! putStrLn  ("Thanks, " + fn) 
+    do! putStrLn  ("What is your last name?")
+    let! ln = getLine
+    let  fullname = fn + " " + ln
+    do! putStrLn  ("Your full name is: " + fullname)
+    return fullname }
+// try -> runIO action ;;
+
+
+
+// List
+
+let lstOf20Elements = map ((+) 100) (take 20 (cycle [1;2;3]))
+
+
+// Applicatives
+
+let just3 :Maybe<_> = return' 3
+let just4           = Just 4
+let just7 = Just (+) <*> just3 <*> just4
+let lst1625 =  (+) <!> [11;20] <*> [5]
+
+
+// Monoids
+
+let res9823 = mconcat (fmap Dual [mempty();"3";"2";"8";"9"])    // Dual "9823"
+let resLtDualGt= mappend  (LT, Dual GT) (mempty())              // (LT, Dual GT)
+
+
+// Monad
+
+// F#                           // Haskell
+let result = 
+    do' {                       // do {
+        let! x1 = [ 1;  2]      //   x1 <- [ 1;  2]
+        let! x2 = [10; 20]      //   x2 <- [10; 20]
+        return ((+) x1 x2) }    //   return ((+) x1 x2) }
+
+// desugared version
+let lst11n21n12n22 = [1; 2] >>= (fun x1 -> [10; 20] >>= (fun x2 ->  return' ((+) x1 x2)))
+
+let just2 = mfilter ((==) 2) (Just 2)
+
+let someListOf42 = replicateM 5 (Some 42)
+
+
+// Arrow
+
+let res3n6n9 = (arr (fun y -> [y; y * 2 ; y * 3])) 3
+let resSome2n4n6:Maybe<_> = runKleisli (arr (fun y -> [y; y * 2 ; y * 3])) 2
+let res500n19 = ((*) 100) *** ((+) 9)  $ (5, 10)
+let res500n14 = ((*) 100) &&& ((+) 9)  $ 5
+let resLeft7  = ((+) 2)   +++ ((*) 10) $ Left  5
+
+
+// Monad transformers
+
+// from http://en.wikibooks.org/wiki/Haskell/Continuation_passing_style
+// askString :: (String -> ContT () IO String) -> ContT () IO String
+let askString next = do' {
+  do! (liftIO $ putStrLn "Please enter a string") 
+  let! s = liftIO $ getLine
+  return! next s}
+
+// reportResult :: String -> IO ()
+let reportResult s = do' {
+  return! putStrLn ("You entered: " + s) }
+  
+let mainAction = runContT (callCC askString) reportResult       //try -> runIO mainAction

--- a/FSharp.Compatibility.Haskell/paket.references
+++ b/FSharp.Compatibility.Haskell/paket.references
@@ -1,0 +1,1 @@
+FSharpPlus

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,7 @@
 source https://nuget.org/api/v2
 
 nuget FSharp.Formatting
+nuget FSharpPlus 1.0.0-CI00089 CI
 nuget NUnit 
 nuget NUnit.Runners
 nuget FAKE
@@ -14,4 +15,3 @@ nuget FsUnit
 nuget MathNet.Numerics
 nuget MathNet.Numerics.FSharp
 nuget Mono.Posix
-

--- a/paket.lock
+++ b/paket.lock
@@ -5,6 +5,7 @@ NUGET
     FAKE (3.34.7)
     FSharp.Compiler.Service (0.0.89)
     FSharp.Core (3.1.2.1)
+    FSharpPlus (1.0.0-CI00089)
     FSharp.Formatting (2.9.6)
       FSharp.Compiler.Service (>= 0.0.87)
       FSharpVSPowerTools.Core (1.8.0)


### PR DESCRIPTION
This is all the code we had in FSharpPlus for Haskell Compatibility, including sample script.
The dependency to F#+ is at version 1.0.0-CI00089 which is the latest in .NET 4.0.
Once this project is migrated to 4.5 or .NET standard we can move to latest F#+ version, with minor adjustments.